### PR TITLE
Reduce cadvisor CPU usage

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -106,6 +106,8 @@ services:
       - "/usr/bin/cadvisor"
       - "-logtostderr"
       - "-docker_only"
+      - "-housekeeping_interval=30s"
+      - "-disable_metrics=memory_numa,tcp,udp,advtcp,sched,process,hugetlb,referenced_memory,cpu_topology,resctrl,cpuset,disk,diskIO,accelerator,percpu"
     networks:
       - vm_net
     restart: always


### PR DESCRIPTION
Reducing cadvisor CPU usage from 18% to below 5% by setting the housekeeping from 1s to 30s, and disabling unnecessary metrics (that we did not even have graphs for in Grafana).
Additionally it fixes the Misc stats on the cadvisor dashboard.